### PR TITLE
add valid flag and search card detail api

### DIFF
--- a/lib/gmo/const.rb
+++ b/lib/gmo/const.rb
@@ -127,6 +127,7 @@ module GMO
       :ret_url               => "RetURL",
       :security_code         => "SecurityCode",
       :seq_mode              => "SeqMode",
+      :valid_flag            => "ValidFlag",
       :service_name          => "ServiceName",
       :service_tel           => "ServiceTel",
       :shop_id               => "ShopID",

--- a/lib/gmo/shop_api.rb
+++ b/lib/gmo/shop_api.rb
@@ -651,6 +651,31 @@ module GMO
         post_request name, options
       end
 
+      ### @params ###
+      # OrderID
+      ### @return ###
+      # CardNo
+      # Brand
+      # DomesticFlag
+      # IssuerCode
+      # DebitPrepaidFlag
+      # DebitPrepaidIssuerName
+      # ForwardFinal
+      # Info1
+      # Info2
+      # Info3
+      # Info4
+      # Info5
+      # ショップID＋オーダーID指定
+      # 各パラメータはショップID＋オーダーID指定のみ設定してください。
+      # /payment/SearchCardDetail.idPass
+      def search_card_detail(options = {})
+        name = "SearchCardDetail.idPass"
+        required = [:order_id]
+        assert_required_options(required, options)
+        post_request name, options
+      end
+
       private
 
         def api_call(name, args = {}, verb = "post", options = {})

--- a/spec/gmo/shop_api_spec.rb
+++ b/spec/gmo/shop_api_spec.rb
@@ -1067,4 +1067,31 @@ describe "GMO::Payment::ShopAPI" do
     end
   end
 
+  describe "#search_card_detail" do
+    it "gets data about card used for given order", :vcr do
+      order_id = @order_id
+      result = @service.search_card_detail({
+        :order_id => order_id
+      })
+
+      result["CardNo"].nil?.should_not be_truthy
+      result["Brand"].nil?.should_not be_truthy
+      result["DomesticFlag"].nil?.should_not be_truthy
+      result["IssuerCode"].nil?.should_not be_truthy
+      result["DebitPrepaidFlag"].nil?.should_not be_truthy
+      result["DebitPrepaidIssuerName"].nil?.should_not be_truthy
+      result["ForwardFinal"].nil?.should_not be_truthy
+      result["Info1"].nil?.should_not be_truthy
+      result["Info2"].nil?.should_not be_truthy
+      result["Info3"].nil?.should_not be_truthy
+      result["Info4"].nil?.should_not be_truthy
+      result["Info5"].nil?.should_not be_truthy
+    end
+
+    it "got error if missing options", :vcr do
+      lambda {
+        result = @service.search_card_detail()
+      }.should raise_error("Required order_id were not provided.")
+    end
+  end
 end


### PR DESCRIPTION
## ✨ 概要
（変更の目的 もしくは 関連する Issue 番号）
　HH様のアプリで物理モードを使用しているため、ValidFlagというパラメーターが必要だが、存在していないため、それを追加するのと、領収書で使うためのSearchCardDetail(MemberIDなし)を追加すること。

## 🛠 変更内容
　valid_flagを追加。
　search_card_detailのAPIを追加。

## 👻 影響範囲
　valid_flagはsearch_cards APIで使われる。
　search_card_detailは新しく追加される。

## ✔️ 動作確認した内容
　valid_flag:物理モードにし、１で有効なカードのみ表示される。０では削除されたカードも含め。
　search_card_detailはorder_idを指定し、その注文で使われたカードの情報（BRANDを含め）を返してくれる。
